### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all 
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,10 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
+  def index
+    @items = Item.all 
+  end
+
   def new
     @item = Item.new
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,12 +125,11 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +140,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +152,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% unless @items.present? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,7 +173,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+      <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,6 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+      <% if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -152,6 +153,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <% end %>
 
       <%# 商品がない場合のダミー %>


### PR DESCRIPTION
# What
### 商品一覧表示機能の実装

# Why
### 出品した商品を一覧で表示し、また商品がない場合はダミーを表示する為
#### - 主な実装作業
 - itemsコントローラーへindexアクションの追加
 - items/indexビューファイルの編集

### - 動作確認用の動画と画像
 - ログイン状態での商品一覧表示
https://gyazo.com/4dbb78adab32ade0cdbcd40ee615c78b
 - ログアウト状態での商品一覧表示
https://gyazo.com/0d241401f7ec2e2c9530fe2408a54624
 - 商品がない状態でのダミー表示
https://gyazo.com/f1a4487b3b850b8f1526005f3e9ef663
確認の不足がございましたら、ご指摘お願いします。

レビューよろしくお願いします！
